### PR TITLE
fix: use strconv package instead of rune/string

### DIFF
--- a/internal/plugins/workload/v1/scaffolds/templates/api/resources/definition.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/api/resources/definition.go
@@ -24,6 +24,9 @@ type Definition struct {
 	// input fields
 	Builder  kinds.WorkloadBuilder
 	Manifest *manifests.Manifest
+
+	// template fields
+	UseStrConv bool
 }
 
 func (f *Definition) SetTemplateDefaults() error {
@@ -34,6 +37,15 @@ func (f *Definition) SetTemplateDefaults() error {
 		f.Builder.GetPackageName(),
 		f.Manifest.SourceFilename,
 	)
+
+	// determine if we need to import the strconv package
+	for _, child := range f.Manifest.ChildResources {
+		if child.UseStrConv {
+			f.UseStrConv = true
+
+			break
+		}
+	}
 
 	f.TemplateBody = definitionTemplate
 	f.IfExistsAction = machinery.OverwriteFile
@@ -47,6 +59,8 @@ const definitionTemplate = `{{ .Boilerplate }}
 package {{ .Builder.GetPackageName }}
 
 import (
+	{{ if .UseStrConv }}"strconv"{{ end }}
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/internal/workload/v1/kinds/workload.go
+++ b/internal/workload/v1/kinds/workload.go
@@ -278,6 +278,12 @@ func (ws *WorkloadSpec) processManifests(markerTypes ...markers.MarkerType) erro
 			childResource.SourceCode = resourceDefinition
 			childResource.StaticContent = manifest
 
+			// HACK: we should handle this better, for now this will work.  we are passing info along that one of our
+			// resources needs to use the strconv package and needs to be included in the generated code.
+			if strings.Contains(resourceDefinition, "strconv.Itoa") || strings.Contains(resourceDefinition, "strconv.FormatBool") {
+				childResource.UseStrConv = true
+			}
+
 			childResources = append(childResources, *childResource)
 		}
 

--- a/internal/workload/v1/manifests/child_resource.go
+++ b/internal/workload/v1/manifests/child_resource.go
@@ -34,6 +34,7 @@ type ChildResource struct {
 	StaticContent string
 	SourceCode    string
 	IncludeCode   string
+	UseStrConv    bool
 	RBAC          *rbac.Rules
 }
 

--- a/internal/workload/v1/markers/markers.go
+++ b/internal/workload/v1/markers/markers.go
@@ -224,7 +224,9 @@ func getSourceCodeFieldVariable(marker FieldMarkerProcessor) (string, error) {
 	case FieldString:
 		return fmt.Sprintf("!!start %s !!end", marker.GetSourceCodeVariable()), nil
 	case FieldInt:
-		return fmt.Sprintf("!!start string(rune(%s)) !!end", marker.GetSourceCodeVariable()), nil
+		return fmt.Sprintf("!!start strconv.Itoa(%s) !!end", marker.GetSourceCodeVariable()), nil
+	case FieldBool:
+		return fmt.Sprintf("!!start strconv.FormatBool(%s) !!end", marker.GetSourceCodeVariable()), nil
 	default:
 		return "", fmt.Errorf("%w with field type %s", ErrInvalidReplaceMarkerFieldType, marker.GetFieldType())
 	}


### PR DESCRIPTION
This issue fixes a previous issue in which rune characters are passed and unable to be used as proper strings.

Signed-off-by: Dustin Scott <dustin.scott18@gmail.com>