### PR TITLE
feat: upgrade to go version 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,82 @@
 module github.com/vmware-tanzu-labs/operator-builder
 
-go 1.16
+go 1.18
 
 require (
-	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator v9.31.0+incompatible
-	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/vmware-tanzu-labs/object-code-generator-for-k8s v0.5.0
-	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
 	sigs.k8s.io/kubebuilder/v3 v3.0.0
+)
+
+require (
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/cloudflare/cfssl v1.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/go-playground/locales v0.14.0 // indirect
+	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/gobuffalo/flect v0.2.2 // indirect
+	github.com/gobuffalo/here v0.6.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/certificate-transparency-go v1.0.21 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/huandu/xstrings v1.3.1 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmoiron/sqlx v1.2.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/markbates/pkger v0.17.1 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/weppos/publicsuffix-go v0.13.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	github.com/zmap/zcrypto v0.0.0-20200911161511-43ff0ea04f21 // indirect
+	github.com/zmap/zlint/v2 v2.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/tools v0.1.2 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.22.2 // indirect
+	k8s.io/apiextensions-apiserver v0.20.1 // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
+	sigs.k8s.io/controller-tools v0.3.0 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.10.10 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1128,7 +1128,6 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/internal/plugins/workload/v1/scaffolds/templates/gomod.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/gomod.go
@@ -9,11 +9,16 @@ import (
 
 var _ machinery.Template = &GoMod{}
 
+const (
+	GoVersion = "1.18"
+)
+
 // GoMod scaffolds a file that defines the project dependencies.
 type GoMod struct {
 	machinery.TemplateMixin
 	machinery.RepositoryMixin
 
+	GoVersion    string
 	Dependencies map[string]string
 }
 
@@ -23,19 +28,20 @@ type GoMod struct {
 // See https://github.com/vmware-tanzu-labs/operator-builder/issues/250
 func goModDependencyMap() map[string]string {
 	return map[string]string{
-		"github.com/go-logr/logr":                    "v0.4.0",
-		"github.com/nukleros/operator-builder-tools": "v0.2.0",
-		"github.com/onsi/ginkgo":                     "v1.16.4",
-		"github.com/onsi/gomega":                     "v1.15.0",
-		"github.com/spf13/cobra":                     "v1.2.1",
-		"github.com/stretchr/testify":                "v1.7.0",
+		"github.com/go-logr/logr":                    "v1.2.3",
+		"github.com/nukleros/operator-builder-tools": "v0.3.0",
+		"github.com/onsi/ginkgo":                     "v1.16.5",
+		"github.com/onsi/gomega":                     "v1.19.0",
+		"github.com/spf13/cobra":                     "v1.4.0",
+		"github.com/stretchr/testify":                "v1.7.3",
+		"google.golang.org/api":                      "v0.84.0",
 		"gopkg.in/yaml.v2":                           "v2.4.0",
-		"k8s.io/api":                                 "v0.22.2",
-		"k8s.io/apimachinery":                        "v0.22.2",
-		"k8s.io/client-go":                           "v0.22.2",
-		"sigs.k8s.io/controller-runtime":             "v0.10.2",
-		"sigs.k8s.io/kubebuilder/v3":                 "v3.2.0",
-		"sigs.k8s.io/yaml":                           "v1.2.0",
+		"k8s.io/api":                                 "v0.24.2",
+		"k8s.io/apimachinery":                        "v0.24.2",
+		"k8s.io/client-go":                           "v0.24.2",
+		"sigs.k8s.io/controller-runtime":             "v0.12.1",
+		"sigs.k8s.io/kubebuilder/v3":                 "v3.4.1",
+		"sigs.k8s.io/yaml":                           "v1.3.0",
 	}
 }
 
@@ -44,6 +50,7 @@ func (f *GoMod) SetTemplateDefaults() error {
 		f.Path = "go.mod"
 	}
 
+	f.GoVersion = GoVersion
 	f.Dependencies = goModDependencyMap()
 	f.TemplateBody = goModTemplate
 	f.IfExistsAction = machinery.OverwriteFile
@@ -54,11 +61,11 @@ func (f *GoMod) SetTemplateDefaults() error {
 const goModTemplate = `
 module {{ .Repo }}
 
-go 1.15
+go {{ .GoVersion }}
 
 require (
-	{{ range $k, $v := $.Dependencies }}
-	"{{ $k }}" {{ $v }}
+	{{ range $package, $version := $.Dependencies }}
+	"{{ $package }}" {{ $version }}
 	{{ end -}}
 )
 `

--- a/internal/plugins/workload/v1/scaffolds/templates/makefile.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/makefile.go
@@ -126,7 +126,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
@@ -141,7 +141,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
The following is addressed with this PR:

- Fixes #31 - upgrade to go version 1.18
- Fixes #22 - using new `desired` package, we can now more accurately determine when a resource is in its true desired state (client-side) or whether it is not and needs reconciliation.  This fixes this issue as the old methodology was inaccurate.