### PR TITLE
ci: fix release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
-      # TODO: readdress this task as it prevented a successful release
-      # See action https://github.com/vmware-tanzu-labs/operator-builder/runs/4861431396?check_suite_focus=true
+      # NOTE: removing support for snapcraft as their CLI has become increasingly unstable and errors have become
+      # common place.  See https://github.com/snapcore/action-publish/issues/28 for an example of some of the issues
+      # that the community has run into.
+      #
       # - name: Set up Snapcraft
       #   # FIXME: the mkdirs are a hack for https://github.com/goreleaser/goreleaser/issues/1715
       #   run: |
@@ -37,18 +39,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: readdress this task as it prevented a successful release
-      # See action https://github.com/vmware-tanzu-labs/operator-builder/runs/4861431396?check_suite_focus=true
+      # NOTE: removing support for snapcraft as their CLI has become increasingly unstable and errors have become
+      # common place.  See https://github.com/snapcore/action-publish/issues/28 for an example of some of the issues
+      # that the community has run into.
+      #
       # - name: Snapcraft Login
       #   if: startsWith(github.ref, 'refs/tags/v')
       #   run: |
       #     snapcraft login --with <(echo "${{ secrets.SNAPCRAFT_LOGIN }}")
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist -f  ./.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     main: ./cmd/operator-builder
     binary: operator-builder
     ldflags:
-      - -s -w -X github.com/vmware-tanzu-labs/operator-builder/pkg/cli.version={{.Version}} -extldflags '-static'
+      - -s -w -X github.com/nukleros/operator-builder/pkg/cli.version={{.Version}} -extldflags '-static'
 
 archives:
   - replacements:
@@ -47,8 +47,8 @@ changelog:
       - '^build(\(.*\))?:'
 dockers:
   - image_templates:
-      - 'ghcr.io/vmware-tanzu-labs/operator-builder:v{{ .Version }}'
-      - 'ghcr.io/vmware-tanzu-labs/operator-builder:latest'
+      - 'ghcr.io/nukleros/operator-builder:v{{ .Version }}'
+      - 'ghcr.io/nukleros/operator-builder:latest'
     dockerfile: Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -62,15 +62,14 @@ dockers:
 brews:
   - name: operator-builder
     tap:
-      owner: vmware-tanzu-labs
+      owner: nukleros
       name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
     # Git author used to commit to the repository.
     # Defaults are shown.
     commit_author:
       name: goreleaserbot
-      email: goreleaser@vmware-tanzu-labs.com
+      email: goreleaser@nukleros.io
 
     # Folder inside the repository to put the formula.
     # Default is the root folder.
@@ -78,7 +77,7 @@ brews:
 
     # Your app's homepage.
     # Default is empty.
-    homepage: "https://github.com/vmware-tanzu-labs/operator-builder"
+    homepage: "https://github.com/nukleros/operator-builder"
 
     # Template of your app's description.
     # Default is empty.
@@ -115,11 +114,11 @@ brews:
       system "#{bin}/operator-builder version"
 nfpms:
   - file_name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    homepage:  https://github.com/vmware-tanzu-labs/operator-builder
+    homepage:  https://github.com/nukleros/operator-builder
     description: "A Kubebuilder plugin to accelerate the development of Kubernetes operators."
-    maintainer: Jeff Davis <jeffda@vmware.com>, Dustin Scott <sduustin@vmware.com>, Rich Lander <lander2k2@protonmail.com>
+    maintainer: Jeff Davis <mr.jefedavis@gmail.com>, Dustin Scott <dustin.scott18@gmail.com>, Rich Lander <lander2k2@protonmail.com>
     license: MIT
-    vendor: VMware Tanzu Labs
+    vendor: Nukleros
     contents:
       - src: ./completions/operator-builder.bash
         dst: /etc/bash_completion.d/operator-builder
@@ -135,8 +134,11 @@ nfpms:
       - kubectl
       - golang
       - make
-# TODO: readdress this task as it prevented a successful release
-# See action https://github.com/vmware-tanzu-labs/operator-builder/runs/4861431396?check_suite_focus=true
+
+# NOTE: removing support for snapcraft as their CLI has become increasingly unstable and errors have become
+# common place.  See https://github.com/snapcore/action-publish/issues/28 for an example of some of the issues
+# that the community has run into.
+#
 # snapcrafts:
 #   - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
 #     name: operator-builder

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/vmware-tanzu-labs/operator-builder)](https://goreportcard.com/report/github.com/vmware-tanzu-labs/operator-builder)
 [![GitHub](https://img.shields.io/github/license/vmware-tanzu-labs/operator-builder)](https://github.com/vmware-tanzu-labs/operator-builder/blob/main/LICENSE)[![GitHub release (latest by date)](https://img.shields.io/github/v/release/vmware-tanzu-labs/operator-builder)](https://github.com/vmware-tanzu-labs/operator-builder/releases)
 [![Hombrew](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/vmware-tanzu-labs/homebrew-tap/master/Info/operator-builder.json&query=$.versions.stable&label=homebrew)](https://github.com/vmware-tanzu-labs/operator-builder/releases)
-[![Get it from the Snap Store](https://badgen.net/snapcraft/v/operator-builder)](https://snapcraft.io/operator-builder)
+<!---[![Get it from the Snap Store](https://badgen.net/snapcraft/v/operator-builder)](https://snapcraft.io/operator-builder)-->
 ![Github Downloads (by Release)](https://img.shields.io/github/downloads/vmware-tanzu-labs/operator-builder/total.svg)
 
 # Operator Builder

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,9 +4,9 @@ You have the following options to install the operator-builder CLI:
 * [Download the latest binary with your browser](https://github.com/nukleros/operator-builder/releases/latest)
 * [Download with wget](#wget)
 * [Homebrew](#homebrew)
-* [Snap](#snap)
 * [Docker Image](#docker-image)
 * [Go Install](#go-install)
+* [Snap](#snap)
 
 ### wget
 Use wget to download the pre-compiled binaries:
@@ -30,20 +30,10 @@ brew tap vmware-tanzu-labs/tap
 brew install operator-builder
 ```
 
-### Snap
-
-Available for Linux only.
-
-```bash
-snap install operator-builder
-```
-
->**NOTE**: `operator-builder` installs with [_strict confinement_](https://docs.snapcraft.io/snap-confinement/6233) in snap, this means it doesn't have direct access to root files.
-
 ### Docker Image
 
 ```bash
-docker pull ghcr.io/vmawre-tanzu-labs/operator-builder
+docker pull ghcr.io/nukleros/operator-builder
 ```
 
 #### One-shot container use
@@ -55,7 +45,7 @@ docker run --rm -v "${PWD}":/workdir ghcr.io/vmware-tanzu-labs/operator-builder 
 #### Run container commands interactively
 
 ```bash
-docker run --rm -it -v "${PWD}":/workdir --entrypoint sh ghcr.io/vmawre-tanzu-labs/operator-builder
+docker run --rm -it -v "${PWD}":/workdir --entrypoint sh ghcr.io/nukleros/operator-builder
 ```
 
 It can be useful to have a bash function to avoid typing the whole docker command:
@@ -72,3 +62,15 @@ operator-builder() {
 GO111MODULE=on go get github.com/vmware-tanzu-labs/operator-builder/cmd/operator-builder
 ```
 
+### Snap
+
+**NOTE:** support for Snaps has been removed due to, what we feel, is increasingly unstable developer experience in publishing snaps.  We can readdress 
+this at such a time where stability to the project has returned.  As of now, the latest available snap for operator-builder is v0.5.0.
+
+Available for Linux only.
+
+```bash
+snap install operator-builder
+```
+
+>**NOTE**: `operator-builder` installs with [_strict confinement_](https://docs.snapcraft.io/snap-confinement/6233) in snap, this means it doesn't have direct access to root files.


### PR DESCRIPTION
Fixes #37 

This addresses the Github actions automation following the move to Nukleros.  It also deprecates support for Snapcraft due to instability in the developer experience with publishing Snaps.

Signed-off-by: Dustin Scott <dustin.scott18@gmail.com>