### PR TITLE
fix: Fixes #49, inject resource info to update PROJECT file

### DIFF
--- a/internal/workload/v1/kinds/api_internal_test.go
+++ b/internal/workload/v1/kinds/api_internal_test.go
@@ -440,7 +440,6 @@ func TestAPIFields_getSampleValue(t *testing.T) {
 				Children:     tt.fields.Children,
 				Default:      tt.fields.Default,
 				Sample:       tt.fields.Sample,
-				Last:         tt.fields.Last,
 			}
 			if got := api.getSampleValue(tt.args.sampleVal); got != tt.want {
 				t.Errorf("APIFields.getSampleValue() = %v, want %v", got, tt.want)
@@ -683,6 +682,9 @@ func TestAPIFields_setCommentsAndDefault(t *testing.T) {
 			},
 			expect: &APIFields{
 				manifestName: "other",
+				Markers: []string{
+					"+kubebuilder:validation:Required",
+				},
 			},
 		},
 	}

--- a/internal/workload/v1/kinds/workload.go
+++ b/internal/workload/v1/kinds/workload.go
@@ -347,7 +347,7 @@ func (ws *WorkloadSpec) processMarkers(manifestFile *manifests.Manifest, markerT
 }
 
 func (ws *WorkloadSpec) processMarkerResults(markerResults []*inspect.YAMLResult) error {
-	for _, markerResult := range markerResults {
+	for i := range markerResults {
 		var defaultFound bool
 
 		var sampleVal interface{}
@@ -355,7 +355,7 @@ func (ws *WorkloadSpec) processMarkerResults(markerResults []*inspect.YAMLResult
 		// convert to interface
 		var marker markers.FieldMarkerProcessor
 
-		switch t := markerResult.Object.(type) {
+		switch t := markerResults[i].Object.(type) {
 		case *markers.FieldMarker:
 			marker = t
 			ws.FieldMarkers = append(ws.FieldMarkers, t)

--- a/internal/workload/v1/markers/markers.go
+++ b/internal/workload/v1/markers/markers.go
@@ -106,8 +106,8 @@ func initializeMarkerInspector(markerTypes ...MarkerType) (*inspect.Inspector, e
 
 	var err error
 
-	for _, markerType := range markerTypes {
-		switch markerType {
+	for i := range markerTypes {
+		switch markerTypes[i] {
 		case FieldMarkerType:
 			err = defineFieldMarker(registry)
 		case CollectionMarkerType:


### PR DESCRIPTION
This commit addresses and issue where not all information for all components are
properly injected into the PROJECT file post-generation.  To fix this, we use
the underlying kubebuilder methods to update a resource, within the scaffold
loop so that the information gets properly propogated to the PROJECT file.  This
will allow us to create webhooks at a later time.

Signed-off-by: Dustin Scott <dustin.scott18@gmail.com>