### PR TITLE
fix: remove appending of descriptions from different markers

### DIFF
--- a/internal/workload/v1/kinds/api.go
+++ b/internal/workload/v1/kinds/api.go
@@ -32,6 +32,7 @@ type APIFields struct {
 }
 
 func (api *APIFields) AddField(path string, fieldType markers.FieldType, comments []string, sample interface{}, hasDefault bool) error {
+
 	obj := api
 
 	parts := strings.Split(path, ".")
@@ -285,7 +286,7 @@ func (api *APIFields) setCommentsAndDefault(comments []string, sampleVal interfa
 	}
 
 	if comments != nil {
-		api.Comments = append(api.Comments, comments...)
+		api.Comments = comments
 	}
 }
 

--- a/internal/workload/v1/kinds/api.go
+++ b/internal/workload/v1/kinds/api.go
@@ -32,7 +32,6 @@ type APIFields struct {
 }
 
 func (api *APIFields) AddField(path string, fieldType markers.FieldType, comments []string, sample interface{}, hasDefault bool) error {
-
 	obj := api
 
 	parts := strings.Split(path, ".")

--- a/internal/workload/v1/kinds/api.go
+++ b/internal/workload/v1/kinds/api.go
@@ -285,7 +285,7 @@ func (api *APIFields) setCommentsAndDefault(comments []string, sampleVal interfa
 		api.appendMarkers("+kubebuilder:validation:Required")
 	}
 
-	if comments != nil {
+	if len(comments) > 0 {
 		api.Comments = comments
 	}
 }

--- a/internal/workload/v1/kinds/api_internal_test.go
+++ b/internal/workload/v1/kinds/api_internal_test.go
@@ -665,8 +665,6 @@ func TestAPIFields_setCommentsAndDefault(t *testing.T) {
 					"(Default: \"string\")",
 				},
 				Comments: []string{
-					"comment1",
-					"comment2",
 					"comment3",
 					"comment4",
 				},


### PR DESCRIPTION
If there are more than two instances of an identical marker with a description, an error will be returned because the descriptions are being appended to one another.  So identical markers throw an error indicating they are different if there are > 2 instances of the identical marker.  This fix removes the append.

Signed-off-by: Rich Lander <lander2k2@protonmail.com>