### PR TITLE
feat: add support for arbitrary field markers

### DIFF
--- a/internal/workload/v1/markers/collection_field_marker.go
+++ b/internal/workload/v1/markers/collection_field_marker.go
@@ -116,6 +116,13 @@ func (cfm *CollectionFieldMarker) IsForCollection() bool {
 	return cfm.forCollection
 }
 
+func (cfm *CollectionFieldMarker) IsArbitrary() bool {
+	if cfm.Arbitrary == nil {
+		return false
+	}
+	return *cfm.Arbitrary
+}
+
 func (cfm *CollectionFieldMarker) SetOriginalValue(value string) {
 	if cfm.GetReplaceText() != "" {
 		cfm.originalValue = cfm.GetReplaceText()

--- a/internal/workload/v1/markers/field_marker.go
+++ b/internal/workload/v1/markers/field_marker.go
@@ -33,6 +33,7 @@ type FieldMarker struct {
 	Default     interface{} `marker:",optional"`
 	Replace     *string
 	Parent      *string
+	Arbitrary   *bool
 
 	// other values which we use to pass information
 	forCollection bool
@@ -42,11 +43,18 @@ type FieldMarker struct {
 
 //nolint:gocritic //needed to implement string interface
 func (fm FieldMarker) String() string {
-	return fmt.Sprintf("FieldMarker{Name: %s Type: %v Description: %q Default: %v}",
+	var arbitraryBool bool
+
+	if fm.Arbitrary != nil {
+		arbitraryBool = *fm.Arbitrary
+	}
+
+	return fmt.Sprintf("FieldMarker{Name: %s Type: %v Description: %q Default: %v Arbitrary: %v}",
 		fm.GetName(),
 		fm.Type,
 		fm.GetDescription(),
 		fm.Default,
+		arbitraryBool,
 	)
 }
 
@@ -131,6 +139,13 @@ func (fm *FieldMarker) IsFieldMarker() bool {
 
 func (fm *FieldMarker) IsForCollection() bool {
 	return fm.forCollection
+}
+
+func (fm *FieldMarker) IsArbitrary() bool {
+	if fm.Arbitrary == nil {
+		return false
+	}
+	return *fm.Arbitrary
 }
 
 func (fm *FieldMarker) SetOriginalValue(value string) {

--- a/internal/workload/v1/markers/markers.go
+++ b/internal/workload/v1/markers/markers.go
@@ -49,6 +49,7 @@ type FieldMarkerProcessor interface {
 	IsCollectionFieldMarker() bool
 	IsFieldMarker() bool
 	IsForCollection() bool
+	IsArbitrary() bool
 
 	SetDescription(string)
 	SetOriginalValue(string)
@@ -284,9 +285,14 @@ func setComments(marker FieldMarkerProcessor, result *inspect.YAMLResult, key, v
 	value.LineComment = strings.ReplaceAll(value.LineComment, replaceText, appendText)
 }
 
-// setValue will set the value appropriately.  This is based on whether the marker has
-// requested replacement text.
+// setValue will set the value appropriately.  If the marker is arbitrary, no
+// value need be set - return immediately.  If the marker has requested
+// replacement text this is set.
 func setValue(marker FieldMarkerProcessor, value *yaml.Node) error {
+	if marker.IsArbitrary() {
+		return nil
+	}
+
 	const varTag = "!!var"
 
 	const strTag = "!!str"


### PR DESCRIPTION
Arbitrary field markers allow custom resource fields to be added that do not map directly to child resource values.  Arbitrary fields may be referenced by resource markers or leveraged in custom mutation logic.

Signed-off-by: Rich Lander <lander2k2@protonmail.com>