### PR TITLE
feat: add metadata.namespace parent marker

### DIFF
--- a/docs/markers.md
+++ b/docs/markers.md
@@ -51,8 +51,8 @@ Example:
 
 ### Parent (required if Name is unspecified)
 
-The parent field in which you wish to substitute.  Currently, only `metadata.name` is supported.
-This will allow you to use the parent name as a value in the child resource.
+The parent field in which you wish to substitute.  Currently, only `metadata.name` and `metadata.namespace` are supported.
+This will allow you to use the parent name or namespace as a value in the child resource.
 
 Example:
 
@@ -60,7 +60,7 @@ Example:
 +operator-builder:field:parent=metadata.name,type=string
 ```
 
-The `metadata.name` field from the collection workload is also supported:
+The `metadata.name` and `metadata.namespace` fields from the collection workload is also supported:
 
 ```
 +operator-builder:collection:field:parent=metadata.name,type=string

--- a/internal/workload/v1/markers/markers.go
+++ b/internal/workload/v1/markers/markers.go
@@ -193,7 +193,8 @@ func reservedMarkers() []string {
 // which are currently supported.
 func supportedParents() map[string]string {
 	return map[string]string{
-		"metadata.name": "Name",
+		"metadata.name":      "Name",
+		"metadata.namespace": "Namespace",
 	}
 }
 

--- a/internal/workload/v1/markers/markers_internal_test.go
+++ b/internal/workload/v1/markers/markers_internal_test.go
@@ -318,11 +318,16 @@ func Test_getSourceCodeVariable(t *testing.T) {
 		Name: &flat,
 	}
 
-	validParent := "metadata.name"
-	invalidParent := "metadata.namespace"
+	validParentName := "metadata.name"
+	validParentNamespace := "metadata.namespace"
+	invalidParent := "metadata.labels"
 
 	fieldMarkerParentTest := &FieldMarker{
-		Parent: &validParent,
+		Parent: &validParentName,
+	}
+
+	fieldMarkerParentNamespaceTest := &FieldMarker{
+		Parent: &validParentNamespace,
 	}
 
 	fieldMarkerInvalidParentTest := &FieldMarker{
@@ -330,7 +335,11 @@ func Test_getSourceCodeVariable(t *testing.T) {
 	}
 
 	collectionFieldMarkerParentTest := &CollectionFieldMarker{
-		Parent: &validParent,
+		Parent: &validParentName,
+	}
+
+	collectionFieldMarkerParentNamespaceTest := &CollectionFieldMarker{
+		Parent: &validParentNamespace,
 	}
 
 	collectionFieldMarkerInvalidParentTest := &CollectionFieldMarker{
@@ -399,6 +408,14 @@ func Test_getSourceCodeVariable(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "ensure field marker with metadata.namespace parent returns a correct source code variable",
+			args: args{
+				marker: fieldMarkerParentNamespaceTest,
+			},
+			want:    "parent.Namespace",
+			wantErr: false,
+		},
+		{
 			name: "ensure field marker with invalid parent returns an error",
 			args: args{
 				marker: fieldMarkerInvalidParentTest,
@@ -412,6 +429,14 @@ func Test_getSourceCodeVariable(t *testing.T) {
 				marker: collectionFieldMarkerParentTest,
 			},
 			want:    "collection.Name",
+			wantErr: false,
+		},
+		{
+			name: "ensure collection field marker with metadata.namespace parent returns a correct source code variable",
+			args: args{
+				marker: collectionFieldMarkerParentNamespaceTest,
+			},
+			want:    "collection.Namespace",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
This also allows metadata.namespace to be added as a parent marker.  Cert Manger is the stone cold use case for this where you need to issue certs containing internal kubernetes service names which always include the namespace:

```
---
# +operator-builder:resource:field=functionIntegrator.nats.type,value=unmanaged,include
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: metadataname-nats-crt # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
  namespace: "nats"
  labels:
    app.kubernetes.io/instance: metadataname-nats # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    app.kubernetes.io/name: nats
spec:
  secretName: metadataname-nats-crt # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
  # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
  # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
  commonName: metadataname-nats.default.svc.cluster.local
  issuerRef:
    name: metadataname-nats-ca-issuer # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    kind: Issuer
  subject:
    organizations:
      - "NATS"
  dnsNames:
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    - "*.default"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    - "*.default.svc"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    - "*.default.svc.cluster.local"
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats.default"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats.default.svc"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats.default.svc.cluster.local"
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats-headless"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats-headless.default"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats-headless.default.svc"
    # +operator-builder:field:parent=metadata.namespace,type=string,replace=default
    # +operator-builder:field:parent=metadata.name,type=string,replace=metadataname
    - "*.metadataname-nats-headless.default.svc.cluster.local"
  privateKey:
    algorithm: RSA
    size: 2048
  duration: 2160h
  renewBefore: 360h
```